### PR TITLE
DM-18417: Investigate excess DIASource detections due to diffim background modeling

### DIFF
--- a/plotLightcurve.py
+++ b/plotLightcurve.py
@@ -309,7 +309,8 @@ def plotLightcurve(obj, objTable, repo, dbName, templateRepo,
         templateCutout = getTemplateCutout(calexpFirst, templateRepo, centerSource)
         templateArray = templateCutout.getMaskedImage().getImage().getArray()
         templateNorm = ImageNormalize(templateArray, interval=ZScaleInterval(), stretch=SqrtStretch())
-        plt.imshow(np.flipud(templateArray), cmap='gray', norm=templateNorm)
+        # plt.imshow(np.flipud(templateArray), cmap='gray', norm=templateNorm)  # wrong orientation
+        plt.imshow(np.fliplr(templateArray), cmap='gray', norm=templateNorm)
     else:  # it's a calexp or an instcal, probably
         for visit in templateVisitList:
             try:


### PR DESCRIPTION
This new notebook isolates the problem related to background modeling and tries a few different approaches, including adding illumination correction to ISR, to fix it. The problem persists, but we understand it a lot better now.